### PR TITLE
Remove array indexing by entityId causes indexing error

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -369,9 +369,6 @@ class AbstractAction
         }
         $values = [];
 
-        foreach ($entityIds as $entityId) {
-            $values[$entityId] = [];
-        }
         $attributes = $this->getAttributes();
         $attributesType = ['varchar', 'int', 'decimal', 'text', 'datetime'];
         foreach ($attributesType as $type) {


### PR DESCRIPTION
### Description
Remove the indexing of the `$values` array. It is unnecessary and introduces and assumption that the `entity_id` and `row_id` are the same in the `catalog_category_entity` table. When the `entity_id` and `row_id` differ then it is possible that the `$values` array can contain indexes for an `entity_id` which will be inserted into the indexer tmp table and when a row with the same `row_id` as this `entity_id` is attempted to insert it will cause a SQL constraint violation on the tmp table.

On line 384 the index of the `$values` array is overwritten by the `row_id` of the row. If the `entity_id` and `row_id` are not the same then some array indexes will not be "filled" by a row. These unfilled indexes create row in the tmp table at insert time which will later be filled by actual `row_id` s from real rows.

e.g. Category Flat Data indexer process unknown error:
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '501' for key 'PRIMARY', query was: INSERT INTO `catalog_category_flat_store_2_tmp` (`row_id`,`entity_id`,`created_in`,`updated_in`,`attribute_set_id`,`parent_id`,`created_at`,`updated_at`,`path`,`position`,`level`,`children_count`,`store_id`,`all_children`,`automatic_sorting`,`available_sort_by`,`children`,`custom_apply_to_products`,`custom_design`,`custom_design_from`,`custom_design_to`,`custom_layout_update`,`custom_use_parent_settings`,`default_sort_by`,`description`,`display_mode`,`filter_price_range`,`fredhopper_category_id`,`image`,`include_in_menu`,`include_vat`,`is_active`,`is_anchor`,`landing_page`,`meta_description`,`meta_keywords`,`meta_title`,`name`,`page_layout`,`path_in_store`,`url_key`,`url_path`) VALUES ...

This seems to be possible when the chunk size is less than the total categories in the tree for a store (we have ~1300) because the same `row_id` gets used twice in 2 different inserts.

### Fixed Issues (if relevant)
Could not find any open issues and bug exists in 

### Manual testing scenarios
1. Create a catalog where the category entities have different `row_id` and `entity_id` (recreated where these value differed by 1) and where there are more than 500 categories in the tree for any 1 store. (500 is the chunk size for the `$entityIds` array)
2. Run the `catalog_category_flat` indexer and get a SQL constraint error - see above

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
